### PR TITLE
chore: include gas price to send transaction

### DIFF
--- a/src/features/deployerWallet/transactions.ts
+++ b/src/features/deployerWallet/transactions.ts
@@ -50,9 +50,7 @@ export async function sendTxFromWallet(
 ): Promise<TypedTransactionReceipt> {
   if (typedTx.type === ProviderType.EthersV5 && typedWallet.type === ProviderType.EthersV5) {
     const provider = multiProvider.getEthersV5Provider(chainName);
-    const connectedWallet = typedWallet.wallet.connect(provider);
-
-    const response = await connectedWallet.sendTransaction({
+    const response = await typedWallet.wallet.connect(provider).sendTransaction({
       ...typedTx.transaction,
       gasPrice,
     });

--- a/src/features/deployerWallet/transactions.ts
+++ b/src/features/deployerWallet/transactions.ts
@@ -46,12 +46,16 @@ export async function sendTxFromWallet(
   typedTx: TypedTransaction,
   chainName: ChainName,
   multiProvider: MultiProtocolProvider,
+  gasPrice: number | bigint,
 ): Promise<TypedTransactionReceipt> {
   if (typedTx.type === ProviderType.EthersV5 && typedWallet.type === ProviderType.EthersV5) {
     const provider = multiProvider.getEthersV5Provider(chainName);
-    const response = await typedWallet.wallet
-      .connect(provider)
-      .sendTransaction(typedTx.transaction);
+    const connectedWallet = typedWallet.wallet.connect(provider);
+
+    const response = await connectedWallet.sendTransaction({
+      ...typedTx.transaction,
+      gasPrice,
+    });
     const receipt = await response.wait();
     return {
       type: ProviderType.EthersV5,


### PR DESCRIPTION
Refund transactions would fail without including the gas price from the estimate, fixed by including it in the `sendTxFromWallet`