### PR TITLE
fix: token metadata handling

### DIFF
--- a/src/features/deployment/warp/deploy.ts
+++ b/src/features/deployment/warp/deploy.ts
@@ -17,12 +17,12 @@ import {
   ProviderType,
   TOKEN_TYPE_TO_STANDARD,
   TokenFactories,
+  TokenMetadataMap,
   WarpCoreConfig,
   WarpRouteDeployConfigMailboxRequired,
   executeWarpDeploy,
   getTokenConnectionId,
   isCollateralTokenConfig,
-  isTokenMetadata,
 } from '@hyperlane-xyz/sdk';
 import { ProtocolType, assert, objMap, sleep } from '@hyperlane-xyz/utils';
 import { useCallback, useMemo, useState } from 'react';
@@ -128,12 +128,12 @@ async function getWarpCoreConfig(
 ): Promise<WarpCoreConfig> {
   const warpCoreConfig: WarpCoreConfig = { tokens: [] };
 
-  const tokenMetadata = await HypERC20Deployer.deriveTokenMetadata(multiProvider, warpDeployConfig);
-  assert(tokenMetadata && isTokenMetadata(tokenMetadata), 'Missing required token metadata');
-  const { decimals, symbol, name } = tokenMetadata;
-  assert(decimals, 'Missing decimals on token metadata');
+  const tokenMetadataMap: TokenMetadataMap = await HypERC20Deployer.deriveTokenMetadata(
+    multiProvider,
+    warpDeployConfig,
+  );
 
-  generateTokenConfigs(warpCoreConfig, warpDeployConfig, contracts, symbol, name, decimals);
+  generateTokenConfigs(warpCoreConfig, warpDeployConfig, contracts, tokenMetadataMap);
 
   fullyConnectTokens(warpCoreConfig);
 
@@ -147,15 +147,19 @@ function generateTokenConfigs(
   warpCoreConfig: WarpCoreConfig,
   warpDeployConfig: WarpRouteDeployConfigMailboxRequired,
   contracts: HyperlaneContractsMap<TokenFactories>,
-  symbol: string,
-  name: string,
-  decimals: number,
+  tokenMetadataMap: TokenMetadataMap,
 ): void {
   for (const [chainName, contract] of Object.entries(contracts)) {
     const config = warpDeployConfig[chainName];
     const collateralAddressOrDenom = isCollateralTokenConfig(config)
       ? config.token // gets set in the above deriveTokenMetadata()
       : undefined;
+
+    const decimals: number | undefined = tokenMetadataMap.getDecimals(chainName);
+    const name: any = tokenMetadataMap.getName(chainName);
+    const symbol: any = tokenMetadataMap.getSymbol(chainName);
+
+    assert(decimals, `Decimals for ${chainName} doesn't exist`);
 
     warpCoreConfig.tokens.push({
       chainName,

--- a/src/features/deployment/warp/deploy.ts
+++ b/src/features/deployment/warp/deploy.ts
@@ -23,6 +23,7 @@ import {
   executeWarpDeploy,
   getTokenConnectionId,
   isCollateralTokenConfig,
+  isXERC20TokenConfig,
 } from '@hyperlane-xyz/sdk';
 import { ProtocolType, assert, objMap, sleep } from '@hyperlane-xyz/utils';
 import { useCallback, useMemo, useState } from 'react';
@@ -151,9 +152,10 @@ function generateTokenConfigs(
 ): void {
   for (const [chainName, contract] of Object.entries(contracts)) {
     const config = warpDeployConfig[chainName];
-    const collateralAddressOrDenom = isCollateralTokenConfig(config)
-      ? config.token // gets set in the above deriveTokenMetadata()
-      : undefined;
+    const collateralAddressOrDenom =
+      isCollateralTokenConfig(config) || isXERC20TokenConfig(config)
+        ? config.token // gets set in the above deriveTokenMetadata()
+        : undefined;
 
     const decimals: number | undefined = tokenMetadataMap.getDecimals(chainName);
     const name: any = tokenMetadataMap.getName(chainName);
@@ -165,7 +167,7 @@ function generateTokenConfigs(
       chainName,
       standard: TOKEN_TYPE_TO_STANDARD[config.type],
       decimals,
-      symbol,
+      symbol: config.symbol || symbol,
       name,
       addressOrDenom: contract[warpDeployConfig[chainName].type as keyof TokenFactories].address,
       collateralAddressOrDenom,

--- a/src/features/deployment/warp/deploy.ts
+++ b/src/features/deployment/warp/deploy.ts
@@ -157,10 +157,11 @@ function generateTokenConfigs(
         : undefined;
 
     const decimals: number | undefined = tokenMetadataMap.getDecimals(chainName);
-    const name: any = tokenMetadataMap.getName(chainName);
-    const symbol: any = tokenMetadataMap.getSymbol(chainName);
+    const name = tokenMetadataMap.getName(chainName);
+    const symbol = tokenMetadataMap.getSymbol(chainName);
 
     assert(decimals, `Decimals for ${chainName} doesn't exist`);
+    assert(name, `Token name for ${chainName} doesn't exist in config`);
 
     warpCoreConfig.tokens.push({
       chainName,

--- a/src/features/deployment/warp/deploy.ts
+++ b/src/features/deployment/warp/deploy.ts
@@ -1,13 +1,5 @@
 // TODO: Most of this file has bee copied from the CLI's /src/deploy/warp.ts
 // Long-term, both should be replaced by EvmERC20WarpModule when it's ready for prod
-import { useMutation } from '@tanstack/react-query';
-import { useToastError } from '../../../components/toast/useToastError';
-import { logger } from '../../../utils/logger';
-import { useMultiProvider } from '../../chains/hooks';
-import { DeployerWallets } from '../../deployerWallet/types';
-import { useDeployerWallets } from '../../deployerWallet/wallets';
-import { WarpDeploymentConfig } from '../types';
-// eslint-disable-next-line camelcase
 import { chainAddresses as registryChainAddresses } from '@hyperlane-xyz/registry';
 import {
   ChainMap,
@@ -26,9 +18,16 @@ import {
   isXERC20TokenConfig,
 } from '@hyperlane-xyz/sdk';
 import { ProtocolType, assert, objMap, sleep } from '@hyperlane-xyz/utils';
+import { useMutation } from '@tanstack/react-query';
 import { useCallback, useMemo, useState } from 'react';
+import { useToastError } from '../../../components/toast/useToastError';
+import { logger } from '../../../utils/logger';
+import { useMultiProvider } from '../../chains/hooks';
 import { hasPendingTx } from '../../deployerWallet/transactions';
+import { DeployerWallets } from '../../deployerWallet/types';
+import { useDeployerWallets } from '../../deployerWallet/wallets';
 import { useStore } from '../../store';
+import { WarpDeploymentConfig } from '../types';
 
 const NUM_SECONDS_FOR_TX_WAIT = 10;
 


### PR DESCRIPTION
This PR fixes the token metadata handling by changing the return type of deriveTokenMetadata to TokenMetadataMap`, 

matching this PR: https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/6175