### PR TITLE
feat: verify create-pr request to prevent spamming

### DIFF
--- a/src/features/deployment/CreateRegistryPrModal.tsx
+++ b/src/features/deployment/CreateRegistryPrModal.tsx
@@ -39,13 +39,6 @@ export function CreateRegistryPrModal({
         </A>
         ? Once your PR is merged, your artifacts will become available for the community to use!
       </p>
-      <p className={styles.text}>
-        <strong>
-          You will be required to sign a message using your wallet to verify your signature. This
-          won&#39;t send any transactions on chain and it is only used to verify the validity of the
-          deployed warp route.
-        </strong>
-      </p>
 
       <p className={styles.text}>
         Optionally, you can include your Github username and organization!

--- a/src/features/deployment/CreateRegistryPrModal.tsx
+++ b/src/features/deployment/CreateRegistryPrModal.tsx
@@ -39,6 +39,13 @@ export function CreateRegistryPrModal({
         </A>
         ? Once your PR is merged, your artifacts will become available for the community to use!
       </p>
+      <p className={styles.text}>
+        <strong>
+          You will be required to sign a message using your wallet to verify your signature. This
+          won&#39;t send any transactions on chain and it is only used to verify the validity of the
+          deployed warp route.
+        </strong>
+      </p>
 
       <p className={styles.text}>
         Optionally, you can include your Github username and organization!

--- a/src/features/deployment/github.ts
+++ b/src/features/deployment/github.ts
@@ -16,7 +16,7 @@ import { normalizeEmptyStrings } from '../../utils/string';
 import { useMultiProvider } from '../chains/hooks';
 import { useLatestDeployment } from './hooks';
 import { DeploymentType } from './types';
-import { getConfigsFilename } from './utils';
+import { getConfigsFilename, sortWarpCoreConfig } from './utils';
 import { isSyntheticTokenType } from './warp/utils';
 
 const warpRoutesPath = 'deployments/warp_routes';
@@ -82,7 +82,7 @@ function getPrCreationBody(
   const { deployConfigFilename, warpConfigFilename } = getConfigsFilename(warpRouteId);
 
   const yamlDeployConfig = stringify(deployConfig, { sortMapEntries: true });
-  const yamlWarpConfig = stringify(warpConfig, { sortMapEntries: true });
+  const yamlWarpConfig = stringify(sortWarpCoreConfig(warpConfig), { sortMapEntries: true });
 
   const basePath = `${warpRoutesPath}/${symbol}`;
   const requestBody: CreatePrBody = {

--- a/src/features/deployment/github.ts
+++ b/src/features/deployment/github.ts
@@ -39,7 +39,7 @@ export function useCreateWarpRoutePR(onSuccess: () => void) {
       const prBody = getPrCreationBody(config.config, result.result, githubInformation);
       const timestamp = `timestamp: ${new Date().toISOString()}`;
       const message = `Verify PR creation for: ${prBody.warpRouteId} ${timestamp}`;
-      const res = await signMessageAsync({
+      const signature = await signMessageAsync({
         message,
       });
 
@@ -48,7 +48,7 @@ export function useCreateWarpRoutePR(onSuccess: () => void) {
         signatureVerification: {
           address: account.addresses[0].address,
           message,
-          signature: res,
+          signature,
         },
       });
     },

--- a/src/flows/LandingCard.tsx
+++ b/src/flows/LandingCard.tsx
@@ -40,7 +40,7 @@ export function LandingPage() {
         </a>
         <SolidButton
           color="accent"
-          onClick={() => setPage(CardPage.WarpForm)}
+          onClick={() => setPage(CardPage.WarpSuccess)}
           className="w-36 px-3 py-2"
         >
           Deploy

--- a/src/pages/api/create-pr.ts
+++ b/src/pages/api/create-pr.ts
@@ -10,6 +10,7 @@ import humanId from 'human-id';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { isHex, verifyMessage } from 'viem';
 import { serverConfig } from '../../consts/config.server';
+import { sortWarpCoreConfig } from '../../features/deployment/utils';
 import { getOctokitClient } from '../../libs/github';
 import { ApiError, ApiSuccess } from '../../types/api';
 import {
@@ -21,6 +22,7 @@ import {
   VerifyPrSignatureSchema,
 } from '../../types/createPr';
 import { sendJsonResponse } from '../../utils/api';
+import { sortObjByKeys } from '../../utils/object';
 import { validateStringToZodSchema, zodErrorToString } from '../../utils/zod';
 
 export default async function handler(
@@ -223,8 +225,11 @@ function getBranchName(
   deployConfig: WarpRouteDeployConfig,
   warpConfig: WarpCoreConfig,
 ): ApiError | ApiSuccess<string> {
-  const deployConfigBuffer = toUtf8Bytes(JSON.stringify(deployConfig));
-  const warpConfigBuffer = toUtf8Bytes(JSON.stringify(warpConfig));
+  const sortedDeployConfig = sortObjByKeys(deployConfig);
+  const sortedWarpCoreConfig = sortObjByKeys(sortWarpCoreConfig(warpConfig));
+
+  const deployConfigBuffer = toUtf8Bytes(JSON.stringify(sortedDeployConfig));
+  const warpConfigBuffer = toUtf8Bytes(JSON.stringify(sortedWarpCoreConfig));
 
   try {
     const requestBodyHash = solidityKeccak256(

--- a/src/pages/api/create-pr.ts
+++ b/src/pages/api/create-pr.ts
@@ -217,7 +217,7 @@ function writeChangeset(description: string): DeployFile {
 ${description.trim()}
 `;
 
-  return { path: `.changset/${filename}`, content };
+  return { path: `.changeset/${filename}`, content };
 }
 
 function getBranchName(

--- a/src/pages/api/create-pr.ts
+++ b/src/pages/api/create-pr.ts
@@ -4,6 +4,7 @@ import {
   WarpRouteDeployConfig,
   WarpRouteDeployConfigSchema,
 } from '@hyperlane-xyz/sdk';
+import { isValidAddressEvm } from '@hyperlane-xyz/utils';
 import { Octokit } from '@octokit/rest';
 import { solidityKeccak256, toUtf8Bytes } from 'ethers/lib/utils';
 import humanId from 'human-id';
@@ -179,8 +180,10 @@ async function validateRequestSignature(
 
   const { address, message, signature } = parsedSignatureBody.data;
 
-  if (!isHex(address)) return { error: 'Address is not a hex string' };
-  if (!isHex(signature)) return { error: 'Signature is a not a hex string' };
+  if (!isHex(address) || !isValidAddressEvm(address))
+    return { error: 'Address is not a valid EVM hex string' };
+  if (!isHex(signature) || !isValidAddressEvm(address))
+    return { error: 'Signature is a not a valid EVM hex string' };
 
   try {
     const isValidSignature = await verifyMessage({

--- a/src/pages/api/create-pr.ts
+++ b/src/pages/api/create-pr.ts
@@ -180,12 +180,16 @@ async function validateRequestSignature(
   if (!isHex(address)) return { error: 'Address is not a hex string' };
   if (!isHex(signature)) return { error: 'Signature is a not a hex string' };
 
-  const isValidSignature = await verifyMessage({
-    address,
-    message,
-    signature,
-  });
-  if (!isValidSignature) return { error: 'Invalid signature' };
+  try {
+    const isValidSignature = await verifyMessage({
+      address,
+      message,
+      signature,
+    });
+    if (!isValidSignature) return { error: 'Invalid signature' };
+  } catch {
+    return { error: 'Invalid signature' };
+  }
 
   // validate that signature is not older than `MAX_TIMESTAMP_DURATION`
   const splitMessage = message.split('timestamp:');

--- a/src/pages/api/create-pr.ts
+++ b/src/pages/api/create-pr.ts
@@ -198,8 +198,8 @@ async function validateRequestSignature(
   }
 
   const currentTimestamp = new Date();
-  const diffInMinutes = (currentTimestamp.getTime() - timestamp.getTime()) / 1000 / 60;
-  if (diffInMinutes > MAX_TIMESTAMP_DURATION) return { error: 'Expired signature' };
+  const diffInMs = currentTimestamp.getTime() - timestamp.getTime();
+  if (diffInMs > MAX_TIMESTAMP_DURATION) return { error: 'Expired signature' };
 
   return { success: true, data: { address, message, signature } };
 }

--- a/src/pages/api/create-pr.ts
+++ b/src/pages/api/create-pr.ts
@@ -29,6 +29,8 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<CreatePrResponse | ApiError>,
 ) {
+  if (req.method !== 'POST') return sendJsonResponse(res, 405, { error: 'Method not allowed' });
+
   const {
     githubBaseBranch,
     githubForkOwner,
@@ -230,7 +232,7 @@ function getBranchName(
   warpConfig: WarpCoreConfig,
 ): ApiError | ApiSuccess<string> {
   const sortedDeployConfig = sortObjByKeys(deployConfig);
-  const sortedWarpCoreConfig = sortObjByKeys(sortWarpCoreConfig(warpConfig));
+  const sortedWarpCoreConfig = sortObjByKeys(sortWarpCoreConfig(warpConfig)!);
 
   const deployConfigBuffer = toUtf8Bytes(JSON.stringify(sortedDeployConfig));
   const warpConfigBuffer = toUtf8Bytes(JSON.stringify(sortedWarpCoreConfig));

--- a/src/types/createPr.ts
+++ b/src/types/createPr.ts
@@ -44,3 +44,16 @@ export const CreatePrBodySchema = z
 export type CreatePrBody = z.infer<typeof CreatePrBodySchema>;
 
 export type CreatePrResponse = ApiResponseBody<CreatePrData>;
+
+export const VerifyPrSignatureSchema = z.object({
+  message: z.string().min(1).describe('Message to be signed'),
+  address: z.string().min(1).describe('Owner of the signed message'),
+  signature: z.string().min(1).describe('The signed message'),
+});
+
+export type VerifyPrSignature = z.infer<typeof VerifyPrSignatureSchema>;
+
+export type CreatePrRequestBody = {
+  prBody: CreatePrBody;
+  signatureVerification: VerifyPrSignature;
+};

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -1,6 +1,6 @@
 import { isObject } from '@hyperlane-xyz/utils';
 
-export function sortObjByKeys(obj: any) {
+export function sortObjByKeys<T extends Record<string, any>>(obj: T): T {
   if (!isObject(obj)) return obj;
 
   return Object.keys(obj)
@@ -8,5 +8,5 @@ export function sortObjByKeys(obj: any) {
     .reduce((acc, key) => {
       acc[key] = obj[key];
       return acc;
-    }, {});
+    }, {}) as T;
 }

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -1,0 +1,12 @@
+import { isObject } from '@hyperlane-xyz/utils';
+
+export function sortObjByKeys(obj: any) {
+  if (!isObject(obj)) return obj;
+
+  return Object.keys(obj)
+    .sort()
+    .reduce((acc, key) => {
+      acc[key] = obj[key];
+      return acc;
+    }, {});
+}


### PR DESCRIPTION
fixes [ENG-1824](https://linear.app/hyperlane-xyz/issue/ENG-1824/rate-limiting-avoid-spamming-of-endpoints)

This PR features different ways to prevent the `create-pr` endpoint from being spammed, the process goes like:

1. In the UI, the temporary deployer wallet will sign a message that contains a `timestamp` and `warpRouteId`.
2. The returned `signature` will be sent to the endpoint along with the `address` and `message`
3. The backend service will verify the signature using viem's `verifySignature` and also check if the `timestamp` has expired (its currently set to 2 minutes)
4. A `keccak256` hash will be created using the `warpRouteId`, `deployConfig` and `warpConfig`, this will be used for the branch name, which will be in `warpRouteId-keccak256hash` format
5. This branch name will be verified using `octokit` so no other branches exists with the same name
6. If every check pass then the PR is created

Rate limiting will be implemented at a later PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clear message in the PR creation modal informing users that wallet signature is required for verification, with no on-chain transaction involved.
  * Introduced wallet-based signature verification for PR creation, enhancing security and authenticity.
  * Implemented deterministic branch naming to prevent duplicate PRs for the same configuration.

* **Bug Fixes**
  * Prevented duplicate pull requests by checking for existing branches with the same configuration.

* **Refactor**
  * Improved internal structure for PR creation and signature verification processes to enhance maintainability.

* **Chores**
  * Added utility for sorting object keys to ensure consistent configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->